### PR TITLE
Change Swift Dev Journal feed URL

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -4373,7 +4373,7 @@
             "title": "Swift Dev Journal",
             "author": "Mark Szymczyk",
             "site_url": "https://www.swiftdevjournal.com/",
-            "feed_url": "https://www.swiftdevjournal.com/feed/"
+            "feed_url": "http://swiftdevjournal.com/index.xml"
           },
           {
             "title": "The Swift Dev.",


### PR DESCRIPTION
I recently migrated my site to Hugo, and that changed the RSS feed URL. This commit has the new URL.